### PR TITLE
Force pybuild to not create __pycache__ files at build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #! /usr/bin/make -f
 
-include /usr/share/dpkg/pkg-info.mk
+export PYTHONDONTWRITEBYTECODE=1
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild


### PR DESCRIPTION
Minimal change to make turnkey-sysinfo reproducible.

FYI `/usr/share/dpkg/pkg-info.mk` just sets some package info env vars which don't appear to be required for our purposes.